### PR TITLE
Add price history page

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from app.config import ALLOWED_CORS_ORIGINS
 from app.database import Base, get_db, get_engine, get_session_local
 
 from app import models
-from app.routes import user, product
+from app.routes import user, product, price_history
 
 # Define the lifespan context manager
 @contextlib.asynccontextmanager
@@ -47,6 +47,9 @@ app.include_router(user.router)
 
 # Product routes
 app.include_router(product.router)
+
+# Price History routes
+app.include_router(price_history.router)
 
 @app.get('/')
 def root():

--- a/backend/app/routes/price_history.py
+++ b/backend/app/routes/price_history.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.models import PriceHistory, Product, User, UserProduct
+from app.auth import get_current_user
+from app.schemas.price_history import ReturnSearchHistoryModel, NotificationFilter
+import itertools
+from typing import Optional
+
+router = APIRouter(
+    prefix="/price-history",
+    tags=["product_history"]
+)
+
+@router.get('/search-price-history', response_model=list[ReturnSearchHistoryModel])
+def get_product_price_history(product_id: Optional[int | str],
+                              name: Optional[str],
+                              notifications: NotificationFilter,
+                              db: Session = Depends(get_db), 
+                              current_user: User = Depends(get_current_user)):
+    """
+    Retrieve the price history of a product by the search parameters.
+    """
+    if product_id == '':
+        product_id = None
+
+    # Get the columns based on output model
+    query = db.query(PriceHistory.id, 
+                     Product.name, 
+                     Product.id.label('product_id'), 
+                     PriceHistory.price, 
+                     PriceHistory.timestamp, 
+                     PriceHistory.source, 
+                     UserProduct.notify.label('notifications')).\
+    join(Product, PriceHistory.product_id == Product.id).\
+    join(UserProduct, UserProduct.product_id == Product.id).\
+    filter(
+        UserProduct.user_id == current_user.id
+    )
+    if product_id is not None:
+        query = query.filter(PriceHistory.product_id == product_id)
+    if name:
+        query = query.filter(Product.name.ilike(f"%{name}%"))
+    if notifications is not NotificationFilter.all:
+        query = query.filter(UserProduct.notify == (True if notifications == NotificationFilter.enabled else False))
+    query = query.order_by(PriceHistory.timestamp.desc())  # Order by timestamp descending
+
+    price_history = query.all()
+    return price_history
+
+@router.get('/', response_model=dict[str, list[ReturnSearchHistoryModel]])
+def get_all_price_histories(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    """
+    Retrieve all price histories for products associated with the current user.
+    """
+    user_products = db.query(UserProduct).filter(UserProduct.user_id == current_user.id).all()
+    if not user_products:
+        return {}
+
+    product_ids = [up.product_id for up in user_products]
+    all_price_histories = db.query(PriceHistory).filter(PriceHistory.product_id.in_(product_ids)).all()
+
+    all_price_histories.sort(key = lambda x: x.timestamp, reverse=True)  # Sort by timestamp descending
+
+    return all_price_histories

--- a/backend/app/routes/product.py
+++ b/backend/app/routes/product.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import Product, PriceHistory, UserProduct, User
 from app.schemas.product import ProductCreate, UserCreateProduct, ProductOut
-from app.schemas.price_history import PriceHistoryOut
 from app.scraper.product_scraper import scrape_product_data
 from app.auth import get_current_user
 from datetime import datetime, timezone
@@ -247,18 +246,6 @@ def update_product(product_id: int, product: ProductCreate, db: Session = Depend
     db.commit()
     db.refresh(existing_product)
     return existing_product
-
-@router.get('/{product_id}/price-history', response_model=list[PriceHistoryOut])
-def get_product_price_history(product_id: int, db: Session = Depends(get_db)):
-    """
-    Retrieve the price history of a product by the given product ID.
-    """
-    product = db.query(Product).filter(Product.id == product_id).first()
-    if not product:
-        raise HTTPException(status_code=404, detail="Product not found")
-    
-    price_history = db.query(PriceHistory).filter(PriceHistory.product_id == product_id).all()
-    return price_history
 
 @router.delete('/{product_id}', response_model=dict)
 def delete_product(product_id: int, db: Session = Depends(get_db)):

--- a/backend/app/schemas/price_history.py
+++ b/backend/app/schemas/price_history.py
@@ -18,7 +18,7 @@ class PriceHistoryOut(BaseModel):
 
 class ReturnSearchHistoryModel(BaseModel):
     id: int
-    name: str | None = Field(..., alias="productName")
+    name: str | None = Field(None, alias="productName")
     product_id: int = Field(..., alias="productId")
     price: float
     timestamp: datetime

--- a/backend/app/schemas/price_history.py
+++ b/backend/app/schemas/price_history.py
@@ -1,5 +1,11 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+from enum import Enum
 from datetime import datetime
+
+class NotificationFilter(Enum):
+    all = "all"
+    enabled = "enabled"
+    disabled = "disabled"
 
 class PriceHistoryOut(BaseModel):
     id: int
@@ -9,3 +15,14 @@ class PriceHistoryOut(BaseModel):
     source: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+class ReturnSearchHistoryModel(BaseModel):
+    id: int
+    name: str | None = Field(..., alias="productName")
+    product_id: int = Field(..., alias="productId")
+    price: float
+    timestamp: datetime
+    source: str | None = None
+    notifications: bool | None = None
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import MainLayout from "./components/MainLayout";
 import Home from "./pages/HomePage";
 import Login from "./pages/LoginPage";
 import Register from "./pages/RegistrationPage";
+import PriceHistoryPage from "./pages/PriceHistoryPage";
 
 // Define the paths in an array
 const homePaths = ["/", "/home"];
@@ -30,6 +31,13 @@ const App = () => {
                             }
                         />
                     ))}
+                    <Route path="/price-history" element={
+                        <ProtectedRoute>
+                            <MainLayout>
+                                <PriceHistoryPage />
+                            </MainLayout>
+                        </ProtectedRoute>
+                    } />
                 </Routes>
             </AuthProvider>
         </Router>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { GiHamburgerMenu } from "react-icons/gi";
 import { IoClose } from "react-icons/io5";
 import { FaHome } from "react-icons/fa";
+import { AiOutlineHistory } from "react-icons/ai";
 
 const Navbar: React.FC = () => {
     const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -102,6 +103,10 @@ const Navbar: React.FC = () => {
                         <Link to="/">
                             <FaHome className="inline-block w-6 h-6 mr-2" />
                             Home
+                        </Link>
+                        <Link to='/price-history'>
+                            <AiOutlineHistory className="inline-block w-6 h-6 mr-2" />
+                            Price Histories
                         </Link>
                     </li>
                 </ul>

--- a/frontend/src/components/PriceHistoryResults.tsx
+++ b/frontend/src/components/PriceHistoryResults.tsx
@@ -23,23 +23,27 @@ const PriceHistoryResults: React.FC<PriceHistoryResultsProps> = ({
     return (
         <div className="mt-8">
             <div className="overflow-x-auto">
-                <div className="grid grid-cols-5 gap-4 text-white border-b border-gray-700 pb-2 mb-2 font-semibold">
+                <div className="grid grid-cols-7 gap-4 text-white border-b border-gray-700 pb-2 mb-2 font-semibold">
                     <div>Id</div>
                     <div>ProductId</div>
+                    <div>Name</div>
                     <div>Price</div>
                     <div>Timestamp</div>
                     <div>Source</div>
+                    <div>Notifications</div>
                 </div>
                 {data.map((item, index) => (
                     <div
                         key={index}
-                        className="grid grid-cols-5 gap-4 text-gray-300 py-2 border-b border-gray-700 hover:bg-gray-600 last:border-b-0"
+                        className="grid grid-cols-7 gap-4 text-gray-300 py-2 border-b border-gray-700 hover:bg-gray-600 last:border-b-0"
                     >
                         <div>{item.id}</div>
                         <div>{item.productId}</div>
+                        <div>{item.productName}</div>
                         <div>${item.price.toFixed(2)}</div>
                         <div>{item.timestamp}</div>
                         <div>{item.source}</div>
+                        <div>{item.notifications ? "Enabled" : "Disabled"}</div>
                     </div>
                 ))}
             </div>

--- a/frontend/src/components/PriceHistoryResults.tsx
+++ b/frontend/src/components/PriceHistoryResults.tsx
@@ -1,0 +1,50 @@
+import type { PriceHistoryResultsProps } from "../types/PriceHistory";
+
+const PriceHistoryResults: React.FC<PriceHistoryResultsProps> = ({
+    data,
+    isLoading,
+}) => {
+    if (isLoading) {
+        return <div className="p-6 text-center text-white">Loading...</div>;
+    }
+
+    if (!data) {
+        return null;
+    }
+
+    if (data.length === 0) {
+        return (
+            <div className="p-6 text-center text-gray-400">
+                No results.
+            </div>
+        );
+    }
+
+    return (
+        <div className="mt-8">
+            <div className="overflow-x-auto">
+                <div className="grid grid-cols-5 gap-4 text-white border-b border-gray-700 pb-2 mb-2 font-semibold">
+                    <div>Id</div>
+                    <div>ProductId</div>
+                    <div>Price</div>
+                    <div>Timestamp</div>
+                    <div>Source</div>
+                </div>
+                {data.map((item, index) => (
+                    <div
+                        key={index}
+                        className="grid grid-cols-5 gap-4 text-gray-300 py-2 border-b border-gray-700 hover:bg-gray-600 last:border-b-0"
+                    >
+                        <div>{item.id}</div>
+                        <div>{item.productId}</div>
+                        <div>${item.price.toFixed(2)}</div>
+                        <div>{item.timestamp}</div>
+                        <div>{item.source}</div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default PriceHistoryResults;

--- a/frontend/src/components/PriceHistorySearch.tsx
+++ b/frontend/src/components/PriceHistorySearch.tsx
@@ -23,11 +23,11 @@ const PriceHistorySearch: React.FC<PriceHistorySearchProps> = ({
                     </label>
                     <input
                         className="mt-1 block w-full p-2 border border-gray-600 rounded bg-gray-700 text-white"
-                        type="text"
+                        type="number"
                         id="productId"
                         placeholder="Enter Product ID"
                         value={productId}
-                        onChange={(e) => setProductId(e.target.value)}
+                        onChange={(e) => setProductId(Number(e.target.value))}
                     />
                 </div>
                 <div className="flex-1">
@@ -57,9 +57,10 @@ const PriceHistorySearch: React.FC<PriceHistorySearchProps> = ({
                         className="mt-1 block w-full p-2 border border-gray-600 rounded bg-gray-700 text-white"
                         name="notifications"
                         id="notifications"
-                        value={notifications ? "enabled" : "disabled"}
-                        onChange={(e) => setNotifications(e.target.value === "enabled")}
+                        value={notifications}
+                        onChange={(e) => setNotifications(e.target.value)}
                     >
+                        <option value="all">All</option>
                         <option value="enabled">Enabled</option>
                         <option value="disabled">Disabled</option>
                     </select>

--- a/frontend/src/components/PriceHistorySearch.tsx
+++ b/frontend/src/components/PriceHistorySearch.tsx
@@ -1,0 +1,72 @@
+import type { PriceHistorySearchProps } from "../types/PriceHistory";
+
+const PriceHistorySearch: React.FC<PriceHistorySearchProps> = ({
+    productId,
+    setProductId,
+    productName,
+    setProductName,
+    notifications,
+    setNotifications,
+}) => {
+    return (
+        <div className="space-y-4">
+            <h2 className="text-2xl font-bold mb-4 text-white">
+                Price History Search
+            </h2>
+            <div className="flex flex-col md:flex-row md:space-x-4 space-y-4 md:space-y-0">
+                <div className="flex-1">
+                    <label
+                        className="block text-sm font-medium text-gray-300 mb-1"
+                        htmlFor="productId"
+                    >
+                        Product ID
+                    </label>
+                    <input
+                        className="mt-1 block w-full p-2 border border-gray-600 rounded bg-gray-700 text-white"
+                        type="text"
+                        id="productId"
+                        placeholder="Enter Product ID"
+                        value={productId}
+                        onChange={(e) => setProductId(e.target.value)}
+                    />
+                </div>
+                <div className="flex-1">
+                    <label
+                        className="block text-sm font-medium text-gray-300 mb-1"
+                        htmlFor="productName"
+                    >
+                        Product Name
+                    </label>
+                    <input
+                        className="mt-1 block w-full p-2 border border-gray-600 rounded bg-gray-700 text-white"
+                        type="text"
+                        id="productName"
+                        placeholder="Enter Product Name"
+                        value={productName}
+                        onChange={(e) => setProductName(e.target.value)}
+                    />
+                </div>
+                <div className="flex-1">
+                    <label
+                        className="block text-sm font-medium text-gray-300 mb-1"
+                        htmlFor="notifications"
+                    >
+                        Notifications
+                    </label>
+                    <select
+                        className="mt-1 block w-full p-2 border border-gray-600 rounded bg-gray-700 text-white"
+                        name="notifications"
+                        id="notifications"
+                        value={notifications ? "enabled" : "disabled"}
+                        onChange={(e) => setNotifications(e.target.value === "enabled")}
+                    >
+                        <option value="enabled">Enabled</option>
+                        <option value="disabled">Disabled</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default PriceHistorySearch;

--- a/frontend/src/components/PriceHistorySearch.tsx
+++ b/frontend/src/components/PriceHistorySearch.tsx
@@ -27,7 +27,7 @@ const PriceHistorySearch: React.FC<PriceHistorySearchProps> = ({
                         id="productId"
                         placeholder="Enter Product ID"
                         value={productId}
-                        onChange={(e) => setProductId(Number(e.target.value))}
+                        onChange={(e) => setProductId(e.target.value === "" ? "" : Number(e.target.value))}
                     />
                 </div>
                 <div className="flex-1">

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -90,6 +90,9 @@ const Home: React.FC = () => {
                             <div className='card-body'>
                                 <h2 className='card-title'>{product.name}</h2>
                                 <p>
+                                    Product ID: {product.id}
+                                </p>
+                                <p>
                                     Current Price: $
                                     {product.currentPrice?.toFixed(2)}
                                 </p>

--- a/frontend/src/pages/PriceHistoryPage.tsx
+++ b/frontend/src/pages/PriceHistoryPage.tsx
@@ -15,17 +15,16 @@ const PriceHistoryPage = () => {
     const [error, setError] = useState<string | null>(null);
 
     const validateSearch = () => {
-        // if the product id cant be set as a number, return an error
-        if (productId && isNaN(Number(productId))) {
+        // Convert productId to a number for validation
+        const productIdNum = Number(productId);
+        if (productId !== "" && isNaN(productIdNum)) {
             setError("Product ID must be a number if entered.");
             return false;
         }
-
-        if (typeof productId === "number" && productId <= 0) {
+        if (productId !== "" && productIdNum <= 0) {
             setError("Product ID must be a positive number.");
             return false;
         }
-
         setError(null);
         return true;
     };

--- a/frontend/src/pages/PriceHistoryPage.tsx
+++ b/frontend/src/pages/PriceHistoryPage.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import PriceHistorySearch from "../components/PriceHistorySearch";
+import PriceHistoryResults from "../components/PriceHistoryResults";
+import type { PriceHistoryItem } from "../types/PriceHistory";
+
+const PriceHistoryPage = () => {
+    const [productId, setProductId] = useState<string>("");
+    const [productName, setProductName] = useState<string>("");
+    const [notifications, setNotifications] = useState<boolean>(false);
+    const [searchResults, setSearchResults] = useState<
+        PriceHistoryItem[] | null
+    >(null);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+
+    const handleSearch = async () => {
+        setIsLoading(true);
+        setSearchResults(null); // Clear previous results
+
+        try {
+            // Use Test data for now till I build the API Route
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+
+            const mockData: PriceHistoryItem[] = [
+                { id: 1, productId: 1, price: 19.99, timestamp: "2024-07-01", source: "Store A" },
+                { id: 2, productId: 1, price: 21.5, timestamp: "2024-07-05", source: "Store B" },
+                { id: 3, productId: 1, price: 18.75, timestamp: "2024-07-10", source: "Store C" },
+            ];
+
+            const data = mockData;
+            setSearchResults(data);
+        } catch (error) {
+            console.error("Failed to fetch data:", error);
+            setSearchResults([]); // Set to empty array on error
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleClear = () => {
+        setProductId("");
+        setProductName("");
+        setNotifications(false);
+        setSearchResults(null);
+    };
+
+    return (
+        <div className="flex flex-col min-h-screen bg-gray-900 text-white p-8 font-sans">
+            <h1 className="text-4xl font-extrabold text-blue-400 mb-8">
+                Product Price History
+            </h1>
+            <PriceHistorySearch
+                productId={productId}
+                setProductId={setProductId}
+                productName={productName}
+                setProductName={setProductName}
+                notifications={notifications}
+                setNotifications={setNotifications}
+            />
+            <div className="mt-6 flex space-x-4">
+                <button
+                    onClick={handleSearch}
+                    className="bg-blue-600 text-white py-2 px-4 rounded-md cursor-pointer font-semibold hover:bg-blue-700 transition-colors duration-200 ease-in-out"
+                >
+                    Search
+                </button>
+                <button
+                    onClick={handleClear}
+                    className="bg-gray-600 text-white py-2 px-4 rounded-md cursor-pointer font-semibold hover:bg-gray-700 transition-colors duration-200 ease-in-out"
+                >
+                    Clear
+                </button>
+            </div>
+            <PriceHistoryResults data={searchResults} isLoading={isLoading} />
+        </div>
+    );
+};
+
+export default PriceHistoryPage;

--- a/frontend/src/types/PriceHistory.tsx
+++ b/frontend/src/types/PriceHistory.tsx
@@ -1,20 +1,22 @@
 // Define the shape of a single price history record
 export interface PriceHistoryItem {
     id: number;
+    productName: string;
     productId: number;
     price: number;
     timestamp: string;
     source: string | null;
+    notifications: boolean | null;
 }
 
 // Define the props for the search component
 export interface PriceHistorySearchProps {
-    productId: string;
-    setProductId: (id: string) => void;
+    productId: string | number;
+    setProductId: (id: string | number) => void;
     productName: string;
     setProductName: (name: string) => void;
-    notifications: boolean;
-    setNotifications: (value: boolean) => void;
+    notifications: string;
+    setNotifications: (value: string) => void;
 }
 
 // Define the props for the results component

--- a/frontend/src/types/PriceHistory.tsx
+++ b/frontend/src/types/PriceHistory.tsx
@@ -1,0 +1,24 @@
+// Define the shape of a single price history record
+export interface PriceHistoryItem {
+    id: number;
+    productId: number;
+    price: number;
+    timestamp: string;
+    source: string | null;
+}
+
+// Define the props for the search component
+export interface PriceHistorySearchProps {
+    productId: string;
+    setProductId: (id: string) => void;
+    productName: string;
+    setProductName: (name: string) => void;
+    notifications: boolean;
+    setNotifications: (value: boolean) => void;
+}
+
+// Define the props for the results component
+export interface PriceHistoryResultsProps {
+    data: PriceHistoryItem[] | null;
+    isLoading: boolean;
+}


### PR DESCRIPTION
Work Done:
Created a Price History Page. 
This page allows users to look at the logs of a product's price history throughout time.
This page has three filters right now:
Product ID: Empty String or Number
Name: String
Notifications: All, Enabled, or Disabled

There are simple validations to this form.

On the backend, I created a new price history endpoint to filter out the user's product's price histories based on the given parameters.