### PR TITLE
feat: Add tests for user field on price history page

### DIFF
--- a/frontend/src/components/PriceHistoryResults.tsx
+++ b/frontend/src/components/PriceHistoryResults.tsx
@@ -20,7 +20,7 @@ const PriceHistoryResults: React.FC<PriceHistoryResultsProps> = ({
     }
 
     return (
-        <div className="mt-8">
+        <div className="mt-8" data-testid="price-history-results">
             <div className="overflow-x-auto">
                 <div className="flex text-white font-semibold border-b border-gray-700 pb-2 mb-2 min-w-max">
                     <div className="flex-1 px-2">Id</div>

--- a/frontend/src/pages/PriceHistoryPage.test.tsx
+++ b/frontend/src/pages/PriceHistoryPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '../utils/test-utils';
+import { render, screen, waitFor, within } from '../utils/test-utils';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import axios from 'axios';
@@ -15,9 +15,23 @@ const mockHistoryData: PriceHistoryItem[] = [
     { id: 2, productId: 102, productName: 'Mouse Y', price: 25.00, timestamp: new Date().toISOString(), source: 'Amazon', notifications: false },
 ];
 
+const mockUsers = [
+    { id: 1, email: 'admin@example.com' },
+    { id: 2, email: 'user@example.com' },
+];
+
 describe('PriceHistoryPage', () => {
     beforeEach(() => {
         mockedAxios.get.mockClear();
+        mockedAxios.get.mockImplementation((url) => {
+            if (url.includes('/users')) {
+                return Promise.resolve({ data: mockUsers });
+            }
+            if (url.includes('/price-history')) {
+                return Promise.resolve({ data: mockHistoryData });
+            }
+            return Promise.reject(new Error('not found'));
+        });
     });
 
     it('renders the search form and buttons', () => {
@@ -30,8 +44,7 @@ describe('PriceHistoryPage', () => {
     });
 
     it('performs a search and displays results', async () => {
-        mockedAxios.get.mockResolvedValue({ data: mockHistoryData });
-        render(<PriceHistoryPage />);
+        render(<PriceHistoryPage />, { mockAuth: { user: { admin: false } }});
 
         const nameInput = screen.getByLabelText(/product name/i);
         const searchButton = screen.getByRole('button', { name: /search/i });
@@ -44,7 +57,7 @@ describe('PriceHistoryPage', () => {
             expect(mockedAxios.get).toHaveBeenCalledWith(
                 'http://localhost:8000/price-history/search-price-history',
                 {
-                    params: { product_id: '', name: 'Laptop', notifications: 'all' },
+                    params: { product_id: '', name: 'Laptop', notifications: 'all', user_filter: null, admin: false },
                     withCredentials: true,
                 }
             );
@@ -58,7 +71,6 @@ describe('PriceHistoryPage', () => {
     });
 
     it('clears the form and results when clear button is clicked', async () => {
-        mockedAxios.get.mockResolvedValue({ data: mockHistoryData });
         render(<PriceHistoryPage />);
 
         const nameInput = screen.getByLabelText(/product name/i);
@@ -80,12 +92,88 @@ describe('PriceHistoryPage', () => {
     });
 
     it('shows "No results." when search returns an empty array', async () => {
-        mockedAxios.get.mockResolvedValue({ data: [] });
+        mockedAxios.get.mockImplementation((url) => {
+            if (url.includes('/users')) {
+                return Promise.resolve({ data: mockUsers });
+            }
+            if (url.includes('/price-history')) {
+                return Promise.resolve({ data: [] });
+            }
+            return Promise.reject(new Error('not found'));
+        });
         render(<PriceHistoryPage />);
 
         const searchButton = screen.getByRole('button', { name: /search/i });
         await userEvent.click(searchButton);
 
         expect(await screen.findByText('No results.')).toBeInTheDocument();
+    });
+});
+
+const mockHistoryDataAdmin: PriceHistoryItem[] = [
+    { id: 1, productId: 101, productName: 'Laptop X', price: 1200.50, timestamp: new Date().toISOString(), source: 'Amazon', notifications: true, userEmail: 'admin@example.com' },
+    { id: 2, productId: 102, productName: 'Mouse Y', price: 25.00, timestamp: new Date().toISOString(), source: 'Amazon', notifications: false, userEmail: 'user@example.com' },
+];
+
+describe('PriceHistoryPage for non-admin users', () => {
+    beforeEach(() => {
+        mockedAxios.get.mockImplementation((url) => {
+            if (url.includes('/users')) {
+                return Promise.resolve({ data: mockUsers });
+            }
+            if (url.includes('/price-history')) {
+                return Promise.resolve({ data: mockHistoryData });
+            }
+            return Promise.reject(new Error('not found'));
+        });
+    });
+
+    it('does not show the user filter', () => {
+        render(<PriceHistoryPage />, { mockAuth: { user: { admin: false } } });
+        expect(screen.queryByLabelText(/user filter/i)).not.toBeInTheDocument();
+    });
+
+    it('does not show the user email column in results', async () => {
+        render(<PriceHistoryPage />, { mockAuth: { user: { admin: false } } });
+
+        const searchButton = screen.getByRole('button', { name: /search/i });
+        await userEvent.click(searchButton);
+
+        await waitFor(() => {
+            expect(screen.queryByText(/user email/i)).not.toBeInTheDocument();
+        });
+    });
+});
+
+describe('PriceHistoryPage for admin users', () => {
+    beforeEach(() => {
+        mockedAxios.get.mockImplementation((url) => {
+            if (url.includes('/users')) {
+                return Promise.resolve({ data: mockUsers });
+            }
+            if (url.includes('/price-history')) {
+                return Promise.resolve({ data: mockHistoryDataAdmin });
+            }
+            return Promise.reject(new Error('not found'));
+        });
+    });
+
+    it('shows the user filter', async () => {
+        render(<PriceHistoryPage />, { mockAuth: { user: { admin: true } } });
+        expect(await screen.findByLabelText(/user filter/i)).toBeInTheDocument();
+    });
+
+    it('shows the user email column in results', async () => {
+        render(<PriceHistoryPage />, { mockAuth: { user: { admin: true } } });
+
+        const searchButton = screen.getByRole('button', { name: /search/i });
+        await userEvent.click(searchButton);
+
+        await waitFor(() => {
+            const resultsContainer = screen.getByTestId('price-history-results');
+            expect(within(resultsContainer).getByText(/user email/i)).toBeInTheDocument();
+            expect(within(resultsContainer).getByText('admin@example.com')).toBeInTheDocument();
+            expect(within(resultsContainer).getByText('user@example.com')).toBeInTheDocument();
+        });
     });
 });

--- a/frontend/src/utils/test-utils.tsx
+++ b/frontend/src/utils/test-utils.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import { render, RenderOptions } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { AuthContext } from "../AuthContext";
+import { AuthContext, AuthState } from "../AuthContext";
 
 // Mock implementation of the User type
 interface User {
@@ -10,19 +10,11 @@ interface User {
     admin: boolean;
 }
 
-// Define the shape of the mock auth state
-interface MockAuthState {
-    isAuthenticated: boolean;
-    user: User | null;
-    isLoading: boolean;
-    login: () => Promise<User>;
-    logout: () => void;
-}
-
 // Default mock state for the AuthContext
-const defaultMockAuth: MockAuthState = {
+const defaultMockAuth: AuthState = {
     isAuthenticated: false,
     user: null,
+    isAdmin: false,
     isLoading: false,
     login: async () => ({ id: 1, email: "test@example.com", admin: false }),
     logout: () => {},
@@ -35,10 +27,16 @@ const renderWithProviders = (
         // Allow overriding the mock auth state for specific tests
         mockAuth = {},
         ...renderOptions
-    }: { mockAuth?: Partial<MockAuthState> } & Omit<RenderOptions, "wrapper"> = {}
+    }: { mockAuth?: Partial<AuthState> } & Omit<RenderOptions, "wrapper"> = {}
 ) => {
     // Combine the default mock auth state with any overrides
     const authValue = { ...defaultMockAuth, ...mockAuth };
+
+    // If a user is provided in the mock, set isAuthenticated and isAdmin accordingly
+    if (mockAuth.user) {
+        authValue.isAuthenticated = true;
+        authValue.isAdmin = mockAuth.user.admin;
+    }
 
     // Define the wrapper component with all necessary providers
     const Wrapper = ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
This commit adds tests for the new user field on the price history page.

The tests cover the following scenarios:
- The user field is not visible for non-admin users.
- The user field is visible for admin users.
- The User Email column in the results grid is not visible for non-admin users.
- The User Email column in the results grid is visible for admin users.

The tests are written using vitest and @testing-library/react. The mock authentication provider has been updated to support mocking admin and non-admin users.